### PR TITLE
Change the logic of Scaling augmentation module (#18)

### DIFF
--- a/demucs_clone/modules/augmentations.py
+++ b/demucs_clone/modules/augmentations.py
@@ -52,6 +52,10 @@ class SignShifting(nn.Module):
 
 
 class Scaling(nn.Module):
+    r"""Scale all the source signals in the given minibatch independantly.
+    The scale factors are independantly sampled from the uniform distribution of the given range.
+    """
+
     def __init__(
             self,
             min_scaler,
@@ -65,11 +69,11 @@ class Scaling(nn.Module):
         signals: torch.Tensor,
     ) -> torch.Tensor:
 
-        scaler = self.uniform_dist.sample([1]).to(signals.device)
-        for i, signal in enumerate(signals):
-            signals[i] = signal*scaler
+        B, S, *_ = signals.size()
+        scalers = self.uniform_dist.sample(torch.Size([B, S])).to(signals.device)
+        scalers = scalers.reshape(B, S, 1, 1)
 
-        return signals
+        return scalers*signals
 
 
 class SourceShuffling(nn.Module):

--- a/tests/test_augmenations.py
+++ b/tests/test_augmenations.py
@@ -2,7 +2,7 @@ import unittest
 
 import torch
 
-from demucs_clone.modules.augmentations import ChannelSwapping, SignShifting
+from demucs_clone.modules.augmentations import ChannelSwapping, Scaling, SignShifting
 
 
 class TestChannelSwapping(unittest.TestCase):
@@ -25,3 +25,35 @@ class TestSignShifting(unittest.TestCase):
         signals = torch.rand(B, S, C, T)
         shifted = self.augmentation(signals)
         assert shifted.add(signals).sum() == 0
+
+
+class TestScaling(unittest.TestCase):
+    def setUp(self):
+        self.augmentation = Scaling(min_scaler=0.25, max_scaler=1.25)
+
+    def test_output_shape_is_maintained(self):
+        B, S, C, T = 2, 4, 2, 10
+        signals = torch.rand(B, S, C, T)
+        scaled = self.augmentation(signals)
+
+        assert scaled.dim() == 4
+        assert scaled.size() == (B, S, C, T)
+
+    def test_scales_along_batch_dims_and_source_dims(self):
+        B, S, C, T = 2, 4, 2, 10
+        signals = torch.ones(B, S, C, T)
+        scaled = self.augmentation(signals)
+
+        # get scalers by indexing all elems in B and S, the first elems in C and T.
+        scalers = scaled[:, :, 0, 0].squeeze()
+
+        assert scalers.reshape(B, S, 1, 1).expand(B, S, C, T).eq(scaled).all()
+
+    def test_scales_independantly(self):
+        B, S, C, T = 10, 4, 2, 10
+        signals = torch.ones(B, S, C, T)
+        scaled = self.augmentation(signals)
+
+        # get scalers by indexing all elems in B and S, the first elems in C and T.
+        scalers = scaled[:, :, 0, 0].squeeze()
+        assert scalers.min() != scalers.max()


### PR DESCRIPTION
 - The Scalinng module was scaling all the values in the input minibatch with a scaler obtained from just one trial.
 - Now the module samples (B x S) scalers from the distribution and multiply them to the each source signals.
 - The augmentations refered from the paper, which introduces SourceShuffing augmentation, gonna be applied in this way.

close #18 