### PR TITLE
Make model size configurable (#27)

### DIFF
--- a/demucs_clone/__main__.py
+++ b/demucs_clone/__main__.py
@@ -70,7 +70,11 @@ def train(args):
         **hparams['dataset']['valid'],
     )
 
-    model = Demucs(sample_rate=hparams['sample_rate'], sources=hparams['sources'])
+    model = Demucs(
+        sample_rate=hparams['sample_rate'],
+        sources=hparams['sources'],
+        **hparams['model'],
+    )
 
     if torch.cuda.is_available():
         model.to(device)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,17 @@
+import unittest
+
+from demucs_clone.modules import Demucs
+
+
+class TestModel(unittest.TestCase):
+    def test_channel_size(self):
+        INITIAL_CHANNEL = 4
+        NUM_LAYERS = 6
+        model = Demucs(num_layers=NUM_LAYERS, initial_channel=INITIAL_CHANNEL)
+
+        channels = [2] + [INITIAL_CHANNEL * 2**layer_idx for layer_idx in range(NUM_LAYERS)]
+
+        encoder_channels = [(getattr(getattr(block, 'block')[0], "in_channels")) for block in model.encoder_conv_blocks]
+        decoder_channels = [(getattr(getattr(block, 'block')[0], "in_channels")) for block in model.decoder_conv_blocks]
+        self.assertEqual(encoder_channels, channels[:-1])
+        self.assertEqual(decoder_channels, list(reversed(channels))[:-1])


### PR DESCRIPTION
Demucs model with the settings introduced in the paper is too big to run training in my environment.

So the model size is to be configurable for the model to fit into my environment.

resolve #27 